### PR TITLE
OpenMP 版本 (WIP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 project( ParallelConvolutionLayer )
 
 find_package( OpenCV REQUIRED )
+find_package(OpenMP REQUIRED)
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 
 add_executable( serial_m serial_matrix.cpp image.cpp filter.cpp )
 target_link_libraries( serial_m ${OpenCV_LIBS} )
 
-# add_executable( thread_m thread_matrix.cpp image.cpp filter.cpp )
-# target_compile_options( thread_m PUBLIC "-pthread")
-# target_link_libraries( thread_m ${OpenCV_LIBS} )
+add_executable( thread_m thread_matrix.cpp image.cpp filter.cpp )
+target_compile_options( thread_m PUBLIC ${OpenMP_CXX_FLAGS} )
+target_link_libraries( thread_m ${OpenCV_LIBS} ${OpenMP_CXX_FLAGS})

--- a/filter.cpp
+++ b/filter.cpp
@@ -26,7 +26,7 @@ void load_filter(const char *filename, int *num_filters, int ***filter_mat, int 
     for(int i = 0; i < *num_filters; i++)
     {
         inFile >> (*filter_size)[i];
-        (*filter_mat)[i] = new int [(*filter_size)[i] * sizeof(int)];
+        (*filter_mat)[i] = new int [(*filter_size)[i] * (*filter_size)[i] * sizeof(int)];
 
         for(int j = 0; j < (*filter_size)[i] * (*filter_size)[i]; j++)
             inFile >> (*filter_mat)[i][j];

--- a/image.cpp
+++ b/image.cpp
@@ -51,6 +51,25 @@ int read_image(char *filename, int **r, int **g, int **b, int *width, int *heigh
     return 0;
 }
 
+void write_image(char *filename, int *r, int *g, int *b, int width, int height)
+{
+    relu(r, g, b, width * height);
+    cv::Mat result_image(height, width, CV_8UC3, cv::Scalar(0, 0, 0));
+
+    for(int i = 0; i < height; i++)
+    {
+        for(int j = 0; j < width; j++)
+        {
+            result_image.at<cv::Vec3b>(i, j)[0] = b[i*width + j];
+            result_image.at<cv::Vec3b>(i, j)[1] = g[i*width + j];
+            result_image.at<cv::Vec3b>(i, j)[2] = r[i*width + j];
+        }
+    }
+
+    cv::imwrite(filename, result_image);
+    return;
+}
+
 void relu(int *r, int *g, int *b, int image_size)
 {
     for(int i = 0; i < image_size; i++)

--- a/image.cpp
+++ b/image.cpp
@@ -87,7 +87,6 @@ void show_image(int *r, int *g, int *b, int width, int height, int use_relu)
     cv::resizeWindow("view", 1280, 720);
     cv::imshow("view", result_image);
     cv::waitKey(0);
-    cv::destroyAllWindows();
     return;
 }
 

--- a/image.h
+++ b/image.h
@@ -6,6 +6,7 @@
 
 int read_image(char *filename, int **r, int **g, int **b, int *width, int *height);
 void relu(int *r, int *g, int *b, int image_size);
+void write_image(char *filename, int *r, int *g, int *b, int width, int height);
 void show_image(int *r, int *g, int *b, int width, int height, int use_relu = USE_RELU);
 void free_image(int *r, int *g, int *b);
 

--- a/serial_matrix.cpp
+++ b/serial_matrix.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
         conv_g = conv_layer(image_g, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
         conv_b = conv_layer(image_b, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
 
-        // sprintf(filename, "thread_out%d.jpg", i);
+        // sprintf(filename, "serial_out%d.jpg", i);
         // write_image(filename, conv_r[i], conv_g[i], conv_b[i], image_width, image_height);
         free_image(conv_r, conv_g, conv_b);
     }

--- a/serial_matrix.cpp
+++ b/serial_matrix.cpp
@@ -35,7 +35,7 @@ int* pad_array(int* input, int width, int height, int padding) {
     int new_width = width+2*padding;
     int new_height = height+2*padding;
     int* padded_array = new int [new_width * new_height * sizeof(int)];
-    memset (padded_array, 0, new_width * new_height * sizeof(int));
+    memset(padded_array, 0, new_width * new_height * sizeof(int));
 
     for(int i = padding; i < new_height-padding; ++i) {
         for(int j = padding; j < new_width-padding; ++j) {
@@ -64,11 +64,9 @@ int* conv_layer(int* matA, int* matB, int a_width, int a_height, int b_size, int
     int ans_height = (new_height-b_size)/step_size + 1;
     int* answer = new int [ans_width * ans_height * sizeof(int)];
 
-    int new_val;
     for(int i = 0; i < ans_height; ++i) {
         for(int j = 0; j < ans_width; ++j) {
-            new_val = dot_product(inputA, matB, b_size, j*step_size, i*step_size, new_width);
-            answer[i*ans_width + j] = new_val;
+            answer[i*ans_width + j] = dot_product(inputA, matB, b_size, j*step_size, i*step_size, new_width);
         }
     }
 
@@ -80,15 +78,10 @@ int* conv_layer(int* matA, int* matB, int a_width, int a_height, int b_size, int
 
 int main(int argc, char** argv) {
 
-    int show_result = 0;
-
     if(argc < 3) {
-        printf("Usage: ./serial_m <image_filename> <filter_filename> [show_result: 1 | 0]\n");
+        printf("Usage: ./serial_m <image_filename> <filter_filename>\n");
         return 0;
     }
-
-    if(argc >= 4)
-        show_result = atoi(argv[3]);
 
     int *image_r, *image_g, *image_b;
     int image_width, image_height;
@@ -104,52 +97,30 @@ int main(int argc, char** argv) {
     int **fil_matrix;
     load_filter(argv[2], &num_filters, &fil_matrix, &fil_size);
 
-    struct timeval t_begin, t_end;
-
     printf("\n******************************************\n");
     printf("Do convolution\n");
 
-    gettimeofday(&t_begin, 0);
-
-    int **conv_r, **conv_g, **conv_b;
-    conv_r = new int* [num_filters];
-    conv_g = new int* [num_filters];
-    conv_b = new int* [num_filters];
+    // char filename[256];
+    int *conv_r, *conv_g, *conv_b;
 
     for(int i = 0; i < num_filters; i++)
     {
-        conv_r[i] = conv_layer(image_r, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
-        conv_g[i] = conv_layer(image_g, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
-        conv_b[i] = conv_layer(image_b, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
-    }
+        conv_r = conv_layer(image_r, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
+        conv_g = conv_layer(image_g, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
+        conv_b = conv_layer(image_b, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
 
-    gettimeofday(&t_end, 0);
+        // sprintf(filename, "thread_out%d.jpg", i);
+        // write_image(filename, conv_r[i], conv_g[i], conv_b[i], image_width, image_height);
+        free_image(conv_r, conv_g, conv_b);
+    }
 
     printf("Convolution done.\n");
     printf("******************************************\n");
 
     //-----------------------------------------------------
-    for(int i = 0; i < num_filters; i++)
-    {
-        printf("filter %d:\n", i);
-        print_filter(fil_matrix[i], fil_size[i]);
-        if(show_result)
-            show_image(conv_r[i], conv_g[i], conv_b[i], image_width, image_height);
-        free_image(conv_r[i], conv_g[i], conv_b[i]);
-    }
-
-    if(show_result)
-        cv::destroyAllWindows();
-
-    delete [] conv_r;
-    delete [] conv_g;
-    delete [] conv_b;
+    free_image(image_r, image_g, image_b);
     free_filter(num_filters, fil_matrix, fil_size);
-    //-----------------------------------------------------
 
-    int sec = t_end.tv_sec - t_begin.tv_sec;
-    int usec = t_end.tv_usec - t_begin.tv_usec;
-    printf("\nSpend %f sec\n", (sec*1000+(usec/1000.0))/1000);
     printf("done.\n");
     return 0;
 }

--- a/thread_matrix.cpp
+++ b/thread_matrix.cpp
@@ -1,11 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <omp.h>
 #include <opencv2/opencv.hpp>
 #include <sys/time.h>
 #include "image.h"
 #include "filter.h"
 using namespace std;
+
+static int num_threads;
 
 /*----------------------------------------------------------------------------------------
     Matrix dot product calculation
@@ -82,13 +85,20 @@ int main(int argc, char** argv) {
 
     int show_result = 0;
 
-    if(argc < 3) {
-        printf("Usage: ./serial_m <image_filename> <filter_filename> [show_result: 1 | 0]\n");
+    if(argc < 4) {
+        printf("Usage: ./serial_m <image_filename> <filter_filename> <number_of_threads> [show_result: 1 | 0]\n");
         return 0;
     }
 
-    if(argc >= 4)
-        show_result = atoi(argv[3]);
+    if(argc >= 5)
+        show_result = atoi(argv[4]);
+
+    num_threads = atoi(argv[3]);
+    omp_set_num_threads(num_threads);
+    printf("\n******************************************\n");
+    printf("Using %d cores with OpenMP\n", num_threads);
+    printf("******************************************\n");
+
 
     int *image_r, *image_g, *image_b;
     int image_width, image_height;
@@ -116,6 +126,7 @@ int main(int argc, char** argv) {
     conv_g = new int* [num_filters];
     conv_b = new int* [num_filters];
 
+    #pragma omp parallel for
     for(int i = 0; i < num_filters; i++)
     {
         conv_r[i] = conv_layer(image_r, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);


### PR DESCRIPTION
## 更動部份
* fix bug in filter.cpp (line 29, 之前版本 new 的 size 錯誤)
* 新增 thread_matrix.cpp <- openmp 版本主程式, 編譯出來的程式名為 *thread_m*
* padding 運用公式算出：`(k - 1) / 2`, 其中 k 為 filter size

## 使用
```bash
./thread_m <image_filename> <filter_filename> <number_of_threads>
```
* 由於跑大量filter時，為了存result可能會導致memory不夠, 故預設是不輸出結果(conv_layer後直接free掉result)
* 提供write_image()，可以把result輸出成圖片檔以檢測正確性

```c++
// thread_matrix.cpp: line 109 ~ 123
// serial_matrix.cpp: line 103 ~ 115
// 將以下程式碼中註解部份消掉重編譯即可使用write_image()
/*************************************************************************************/

// char filename[256];
int *conv_r, *conv_g, *conv_b;

for(int i = 0; i < num_filters; i++)
{
    conv_r = conv_layer(image_r, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
    conv_g = conv_layer(image_g, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);
    conv_b = conv_layer(image_b, fil_matrix[i], image_width, image_height, fil_size[i], (fil_size[i]-1) / 2);

    // sprintf(filename, "thread_out%d.jpg", i);
    // write_image(filename, conv_r[i], conv_g[i], conv_b[i], image_width, image_height);
    free_image(conv_r, conv_g, conv_b);
}
```
## 平行化部份
* 平均分配給每個 core 幾個 filter 處理 (thread_matrix.cpp line 129)